### PR TITLE
Use latest tiller, fix name

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -4,7 +4,8 @@ description: Installs tiller for single-namespace use
 bindable: False
 async: optional
 metadata:
-  displayName: tiller (APB)
+  displayName: Tiller (APB)
+  imageUrl: 'https://www.helm.sh/assets/images/helm-logo.svg'
 plans:
   - name: default
     description: This default plan deploys tiller-apb

--- a/roles/tiller-apb/tasks/main.yml
+++ b/roles/tiller-apb/tasks/main.yml
@@ -46,7 +46,7 @@
         value: '{{ namespace }}'
       - name: TILLER_HISTORY_MAX
         value: "0"
-      image: gcr.io/kubernetes-helm/tiller:v2.8.1
+      image: gcr.io/kubernetes-helm/tiller
       imagePullPolicy: IfNotPresent
       livenessProbe:
         httpGet:


### PR DESCRIPTION
As it is now, we run into server/client mismatches. I guess the other option is to use the 2.8.2 helm in helm-bundle-base.
